### PR TITLE
Fix documentation issue in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ brew install pdf-diff
 ```
 
 ```sh
-$ go pdf-diff pdf-1.pdf pdf-2.pdf
+$ pdf-diff pdf-1.pdf pdf-2.pdf
 ```
 
 Once ran, the images are created in the folder `generated`.


### PR DESCRIPTION
Hi, thanks for a great tool.
While reviewing the documentation, I noticed a small issue with the guidelines that I would like to address in this pull request.

Specifically the documentation mentions the following: - 
> For [Homebrew](https://brew.sh/) users:
> 
> `$ brew install pdf-diff`
> `$ go pdf-diff pdf-1.pdf pdf-2.pdf`

The second statement includes 'go' prefix which when ran, I got the following error: - 
<img width="207" alt="Screenshot 2023-05-09 at 1 28 41 AM" src="https://user-images.githubusercontent.com/25889447/236878403-25ec1296-c704-4b7e-91c5-a317b87bfad5.png">

However removing 'go' worked as expected,
> `$ go pdf-diff pdf-1.pdf pdf-2.pdf` ~> `$ pdf-diff pdf-1.pdf pdf-2.pdf`

This PR aims to fix the issue mentioned in the documentation. Please let me know if I have misunderstood any part of the documentation. Thank you.


